### PR TITLE
fix: random fatal error failures during teardown

### DIFF
--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -110,6 +110,7 @@ describe OroGen.motors_weg_cvw300.Task do
         it "outputs the fault state on start" do
             now = Time.now
             sample = modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
                 have_one_new_sample task.fault_state_port
             end
 


### PR DESCRIPTION
The issue is that this test was checking the reception of a sample during start, but not the emission of the start event. This caused the test's own teardown to not explicitly stop the task, which left it to Syskit's own teardown procedure. During which the "fake modbus" driver was not present.