### PR TITLE
fix: random test failures

### DIFF
--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -62,7 +62,7 @@ describe OroGen.motors_weg_cvw300.Task do
     end
 
     after do
-        modbus_stop_task if task&.running?
+        modbus_stop_task if task&.running? && !task&.finishing?
     end
 
     describe "configuration" do


### PR DESCRIPTION
Tests that cause an exception actually do not wait for the task to stop. The task is finishing but still running, which
allows the teardown to call stop!. This creates then an error (transition failed) down the line.

Hopefully the last of the heisenbug in this package. I had it run 12h without issues.