### PR TITLE
fix: misuse of modbus_expect_execution

### DIFF
--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -277,7 +277,7 @@ describe OroGen.motors_weg_cvw300.Task do
                 ]
             )
             syskit_write task.cmd_in_port, cmd
-            modbus_expect_execution(@writer, @reader) do
+            modbus_expect_execution(@writer, @reader).to do
                 emit task.invalid_command_size_event
             end
         end
@@ -289,7 +289,7 @@ describe OroGen.motors_weg_cvw300.Task do
                 elements: [Types.base.JointState.Speed(Float::NAN)]
             )
             syskit_write task.cmd_in_port, cmd
-            modbus_expect_execution(@writer, @reader) do
+            modbus_expect_execution(@writer, @reader).to do
                 emit task.invalid_command_parameter_event
             end
         end


### PR DESCRIPTION
The block for modbus_expect_execution is the block given to expect_execution. For assertions, we need to call `.to { }`