### PR TITLE
fix: Always update alarm state

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -136,12 +136,10 @@ void Task::updateHook()
     _inverter_state.write(state_out);
 
     int current_alarm = m_driver->readCurrentAlarm();
-    if (current_alarm) {
-        AlarmState alarmState;
-        alarmState.time = Time::now();
-        alarmState.current_alarm = current_alarm;
-        _alarm_state.write(alarmState);
-    }
+    AlarmState alarmState;
+    alarmState.time = Time::now();
+    alarmState.current_alarm = current_alarm;
+    _alarm_state.write(alarmState);
 
     if (now - m_last_temperature_update > _temperature_period.get()) {
         _temperatures.write(m_driver->readTemperatures());

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -147,6 +147,15 @@ describe OroGen.motors_weg_cvw300.Task do
             assert_equal 1, sample.current_alarm
         end
 
+        it "outputs an zeroed alarm state structure if there is no alarm" do
+            modbus_configure_and_start
+
+            now = Time.now
+            sample = modbus_expect_execution(@writer, @reader).to { have_one_new_sample task.alarm_state_port }
+            assert Time.at(now.tv_sec, 0) < sample.time
+            assert_equal 0, sample.current_alarm
+        end
+
         it "outputs a fault state structure and transitions to fault if the inverter is in under-voltage" do
             modbus_configure_and_start
 


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
The alarm state output port does not update when the alarm is deactivated. To implement alarm reporting, it was necessary to report when the alarm is deactivated.
[sc-39503]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [x] Unit tests
