### PR TITLE
feat: Implements the automatic controller faults reset

### DIFF
--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -87,8 +87,8 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
 
     output_port "saturation_signal", "/control_base/SaturationSignal"
 
-    exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER",
-                     "CONTROLLER_FAULT", "CONTROLLER_UNDER_VOLTAGE"
+    exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER"
+    error_states "CONTROLLER_FAULT", "CONTROLLER_UNDER_VOLTAGE"
 
     # There's no data coming from the controller without the driver requesting
     # it first ... Must be periodic.

--- a/motors_weg_cvw300Types.hpp
+++ b/motors_weg_cvw300Types.hpp
@@ -5,6 +5,7 @@
 #include <motors_weg_cvw300/Configuration.hpp>
 #include <motors_weg_cvw300/FaultState.hpp>
 #include <motors_weg_cvw300/InverterStatus.hpp>
+#include <motors_weg_cvw300/CurrentState.hpp>
 
 namespace motors_weg_cvw300 {
     namespace configuration {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -110,31 +110,8 @@ bool Task::checkSpeedSaturation(base::commands::Joints const& cmd)
     return cmd.elements[0].speed >= m_limits.elements[0].max.speed ||
            cmd.elements[0].speed <= m_limits.elements[0].min.speed;
 }
-
-void Task::updateHook()
+CurrentState Task::readAndPublishControllerStates()
 {
-    while (_cmd_in.read(m_cmd_in) == RTT::NewData) {
-        if (m_cmd_in.elements.size() != 1) {
-            return exception(INVALID_COMMAND_SIZE);
-        }
-
-        auto joint = m_cmd_in.elements.at(0);
-        if (!joint.isSpeed()) {
-            return exception(INVALID_COMMAND_PARAMETER);
-        }
-
-        writeSpeedCommand(joint.speed);
-
-        SaturationSignal saturation_signal;
-        saturation_signal.value = checkSpeedSaturation(m_cmd_in);
-        saturation_signal.time = m_cmd_in.time;
-        _saturation_signal.write(saturation_signal);
-    }
-
-    if (commandTimedOut()) {
-        writeSpeedCommand(0);
-    }
-
     auto now = Time::now();
     CurrentState state = m_driver->readCurrentState();
     m_sample.time = now;
@@ -166,22 +143,50 @@ void Task::updateHook()
         _temperatures.write(m_driver->readTemperatures());
         m_last_temperature_update = now;
     }
-
-    if (state.inverter_status == STATUS_FAULT) {
-        publishFault();
-        return exception(CONTROLLER_FAULT);
+    return state;
+}
+void Task::evaluateInverterStatus(InverterStatus const& inverter_status)
+{
+    if (inverter_status == STATUS_FAULT) {
+        error(CONTROLLER_FAULT);
     }
-    else if (state.inverter_status == STATUS_UNDERVOLTAGE) {
-        publishFault();
-        return exception(CONTROLLER_UNDER_VOLTAGE);
+    else if (inverter_status == STATUS_UNDERVOLTAGE) {
+        error(CONTROLLER_UNDER_VOLTAGE);
     }
-
-    TaskBase::updateHook();
 }
 void Task::publishFault()
 {
     auto fault_state = m_driver->readFaultState();
     _fault_state.write(fault_state);
+}
+void Task::updateHook()
+{
+    while (_cmd_in.read(m_cmd_in) == RTT::NewData) {
+        if (m_cmd_in.elements.size() != 1) {
+            return exception(INVALID_COMMAND_SIZE);
+        }
+
+        auto joint = m_cmd_in.elements.at(0);
+        if (!joint.isSpeed()) {
+            return exception(INVALID_COMMAND_PARAMETER);
+        }
+
+        writeSpeedCommand(joint.speed);
+
+        SaturationSignal saturation_signal;
+        saturation_signal.value = checkSpeedSaturation(m_cmd_in);
+        saturation_signal.time = m_cmd_in.time;
+        _saturation_signal.write(saturation_signal);
+    }
+
+    if (commandTimedOut()) {
+        writeSpeedCommand(0);
+    }
+
+    auto state = readAndPublishControllerStates();
+    evaluateInverterStatus(state.inverter_status);
+
+    TaskBase::updateHook();
 }
 void Task::processIO()
 {
@@ -189,6 +194,21 @@ void Task::processIO()
 void Task::errorHook()
 {
     TaskBase::errorHook();
+
+    publishFault();
+
+    // Try to reset the faults
+    m_driver->prepare();
+    // Verify if the controller status is not in FAULT state
+    auto state = readAndPublishControllerStates();
+    if (state.inverter_status != STATUS_FAULT &&
+        state.inverter_status != STATUS_UNDERVOLTAGE) {
+        recover();
+    }
+
+    if (_cmd_in.read(m_cmd_in) == RTT::NewData) {
+        evaluateInverterStatus(state.inverter_status);
+    }
 }
 void Task::stopHook()
 {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -198,11 +198,12 @@ void Task::errorHook()
     publishFault();
 
     // Try to reset the faults
-    m_driver->prepare();
+    m_driver->resetFault();
     // Verify if the controller status is not in FAULT state
     auto state = readAndPublishControllerStates();
     if (state.inverter_status != STATUS_FAULT &&
         state.inverter_status != STATUS_UNDERVOLTAGE) {
+        m_driver->enable();
         recover();
     }
 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -46,6 +46,8 @@ namespace motors_weg_cvw300 {
         bool commandTimedOut() const;
         void publishFault();
         bool checkSpeedSaturation(base::commands::Joints const& cmd);
+        void evaluateInverterStatus(InverterStatus const& inverter_status);
+        CurrentState readAndPublishControllerStates();
 
     public:
         /** TaskContext constructor for Task


### PR DESCRIPTION
Depends on:
- [x] https://github.com/tidewise/drivers-motors_weg_cvw300/pull/13 

# What is this PR for
The controller faults should not return an exception anymore, now it should return an error state instead and try to reset the fault automatically.
[sc-59810]

# How I did it
Move the exception states: "CONTROLLER_FAULT", "CONTROLLER_UNDER_VOLTAGE"to be error states.
When in error state, the component should be able to try to reset the faults automatically and verify the inverter stops reporting a fault state.

# Results, How I tested
unit test
I still need test it on live system

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
