### PR TITLE
fix: read cmd in once per update hook

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -161,7 +161,7 @@ void Task::publishFault()
 }
 void Task::updateHook()
 {
-    while (_cmd_in.read(m_cmd_in) == RTT::NewData) {
+    if (_cmd_in.read(m_cmd_in) == RTT::NewData) {
         if (m_cmd_in.elements.size() != 1) {
             return exception(INVALID_COMMAND_SIZE);
         }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -161,6 +161,8 @@ void Task::publishFault()
 }
 void Task::updateHook()
 {
+    TaskBase::updateHook();
+
     if (_cmd_in.read(m_cmd_in) == RTT::NewData) {
         if (m_cmd_in.elements.size() != 1) {
             return exception(INVALID_COMMAND_SIZE);
@@ -185,8 +187,6 @@ void Task::updateHook()
 
     auto state = readAndPublishControllerStates();
     evaluateInverterStatus(state.inverter_status);
-
-    TaskBase::updateHook();
 }
 void Task::processIO()
 {


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
### What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
If cmd_in frequency is higher than communication frequency this can result in an endless update hook
