### PR TITLE
feat: Create a component to reset the contactor fault F185

### DIFF
--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -15,6 +15,7 @@ import_types_from "motors_weg_cvw300Types.hpp"
 using_task_library "iodrivers_base"
 using_library "control_base"
 import_types_from "control_base"
+import_types_from "linux_gpios"
 
 task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
@@ -93,4 +94,29 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # There's no data coming from the controller without the driver requesting
     # it first ... Must be periodic.
     periodic 0.1
+end
+
+task_context "ContactorFaultResetTask" do
+    needs_configuration
+
+    # Waiting time between disable the gpio_propulsion and enable it again.
+    property "propulsion_disabled_duration", "/base/Time"
+    # Number of attempts to try changing the contactor fault F185 to the external fault
+    # F91
+    property "number_of_attempts_to_change_controller_failure", "int"
+
+    # Port motor controller fault state
+    input_port "port_fault_state", "/motors_weg_cvw300/FaultState"
+    # Starboard motor controller fault state
+    input_port "starboard_fault_state", "/motors_weg_cvw300/FaultState"
+    # Current gpio_propulsion_enable state
+    input_port "propulsion_enable_in", "/linux_gpios/GPIOState"
+    # Signal to control the gpio_propulsion_enable when the motor controller is reporting
+    # contactor fault
+    output_port "propulsion_enable_out", "/linux_gpios/GPIOState"
+    # Signal to control the gpio_motor_controller_fault_reset_enable when the motor
+    # controller is still reporting contactor fault
+    output_port "motor_controller_fault_reset_enable", "/linux_gpios/GPIOState"
+
+    port_driven
 end

--- a/tasks/ContactorFaultResetTask.cpp
+++ b/tasks/ContactorFaultResetTask.cpp
@@ -1,0 +1,98 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "ContactorFaultResetTask.hpp"
+
+using namespace motors_weg_cvw300;
+using namespace linux_gpios;
+
+ContactorFaultResetTask::ContactorFaultResetTask(std::string const& name)
+    : ContactorFaultResetTaskBase(name)
+{
+}
+
+ContactorFaultResetTask::~ContactorFaultResetTask()
+{
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See ContactorFaultResetTask.hpp for more detailed
+// documentation about them.
+
+bool ContactorFaultResetTask::configureHook()
+{
+    if (!ContactorFaultResetTaskBase::configureHook())
+        return false;
+
+    m_propulsion_disabled_duration = _propulsion_disabled_duration.get();
+    m_number_of_attempts_to_change_controller_failure =
+        _number_of_attempts_to_change_controller_failure.get();
+    return true;
+}
+bool ContactorFaultResetTask::startHook()
+{
+    if (!ContactorFaultResetTaskBase::startHook())
+        return false;
+    m_number_of_contactor_faults = 0;
+    return true;
+}
+void ContactorFaultResetTask::updateHook()
+{
+    ContactorFaultResetTaskBase::updateHook();
+
+    GPIOState current_propulsion_enable_state;
+    if (_propulsion_enable_in.read(current_propulsion_enable_state) == RTT::NoData) {
+        return;
+    }
+
+    FaultState port_fault_state, starboard_fault_state;
+    if (_port_fault_state.read(port_fault_state) == RTT::NewData ||
+        _starboard_fault_state.read(starboard_fault_state) == RTT::NewData) {
+        // F185 - Contactor Fault
+        if ((port_fault_state.current_fault == 185 ||
+                starboard_fault_state.current_fault == 185) &&
+            current_propulsion_enable_state.states[0].data == true) {
+            m_number_of_contactor_faults++;
+            if (m_number_of_contactor_faults <=
+                m_number_of_attempts_to_change_controller_failure) {
+                // Try to change the controller fault triggering the external fault F91
+                _propulsion_enable_out.write(GPIO(false));
+                sleep(m_propulsion_disabled_duration.toSeconds());
+                _propulsion_enable_out.write(GPIO(true));
+            }
+            else {
+                // Hard reset
+                _motor_controller_fault_reset_enable.write(GPIO(false));
+                _motor_controller_fault_reset_enable.write(GPIO(true));
+                _motor_controller_fault_reset_enable.write(GPIO(false));
+            }
+        }
+        else if ((port_fault_state.current_fault == 0 &&
+                     starboard_fault_state.current_fault == 0) ||
+                 current_propulsion_enable_state.states[0].data == false) {
+            m_number_of_contactor_faults = 0;
+        }
+    }
+}
+
+GPIOState ContactorFaultResetTask::GPIO(bool flag)
+{
+    auto now = base::Time::now();
+    GPIOState gpio;
+    gpio.time = now;
+    gpio.states[0].time = now;
+    gpio.states[0].data = flag;
+    return gpio;
+}
+
+void ContactorFaultResetTask::errorHook()
+{
+    ContactorFaultResetTaskBase::errorHook();
+}
+void ContactorFaultResetTask::stopHook()
+{
+    ContactorFaultResetTaskBase::stopHook();
+}
+void ContactorFaultResetTask::cleanupHook()
+{
+    ContactorFaultResetTaskBase::cleanupHook();
+}

--- a/tasks/ContactorFaultResetTask.hpp
+++ b/tasks/ContactorFaultResetTask.hpp
@@ -1,0 +1,111 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef MOTORS_WEG_CVW300_CONTACTORFAULTRESETTASK_TASK_HPP
+#define MOTORS_WEG_CVW300_CONTACTORFAULTRESETTASK_TASK_HPP
+
+#include "motors_weg_cvw300/ContactorFaultResetTaskBase.hpp"
+
+namespace motors_weg_cvw300 {
+
+    /*! \class ContactorFaultResetTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','motors_weg_cvw300::ContactorFaultResetTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
+     */
+    class ContactorFaultResetTask : public ContactorFaultResetTaskBase {
+        friend class ContactorFaultResetTaskBase;
+
+    private:
+        base::Time m_propulsion_disabled_duration;
+        size_t m_number_of_attempts_to_change_controller_failure = 0;
+        size_t m_number_of_contactor_faults = 0;
+
+        linux_gpios::GPIOState GPIO(bool flag);
+
+    public:
+        /** TaskContext constructor for ContactorFaultResetTask
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
+         */
+        ContactorFaultResetTask(
+            std::string const& name = "motors_weg_cvw300::ContactorFaultResetTask");
+
+        /** Default deconstructor of ContactorFaultResetTask
+         */
+        ~ContactorFaultResetTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
[sc-67668]
It creates a component to monitor the F185 fault on both controllers and when the fault occurs on a controller, it tries to reset it in two ways.
First:
- It tries to change the current fault from F185 (contactor fault) to F091 (external fault)
- Triggering the external fault through the gpio_propulsion_enable
Second:
- It tries to hard reset the current fault F185 disabling the power.
- Triggering the DI4 (P266 - RESET) through the gpio_motor_controller_fault_reset_enable

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) 

