### PR TITLE
fix: Add a property to report the fault state periodically instead of edge-triggered

### DIFF
--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -71,6 +71,12 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     property "registers_configuration",
              "/std/vector</motors_weg_cvw300/configuration/MotorRegister>"
 
+    # Edge trigger the fault_state output port
+    #
+    # When set as true, it just reports the fault state when it happens in the controller.
+    # When set as false, it reports the fault state periodically.
+    property "edge_triggered_fault_state_output", "/bool", true
+
     # Input command
     #
     # Only set the speed field

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -75,6 +75,7 @@ bool Task::configureHook()
     m_sample.elements.resize(1);
 
     m_inverted = _inverted.get();
+    m_edge_triggered_fault_state_output = _edge_triggered_fault_state_output.get();
 
     m_driver = move(driver);
     guard.commit();
@@ -185,6 +186,9 @@ void Task::updateHook()
         writeSpeedCommand(0);
     }
 
+    if (!m_edge_triggered_fault_state_output) {
+        publishFault();
+    }
     auto state = readAndPublishControllerStates();
     evaluateInverterStatus(state.inverter_status);
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -41,6 +41,7 @@ namespace motors_weg_cvw300 {
         std::unique_ptr<Driver> m_driver;
 
         bool m_inverted;
+        bool m_edge_triggered_fault_state_output;
 
         void writeSpeedCommand(float cmd);
         bool commandTimedOut() const;


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
[sc-73061]

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
