### PR TITLE
feat: implement contactor fault

### DIFF
--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -129,6 +129,10 @@ task_context "SimulationTask" do
 
     input_port "external_fault_gpio", "/linux_gpios/GPIOState"
 
+    input_port "port_power_disable_gpio", "/linux_gpios/GPIOState"
+
+    input_port "starboard_power_disable_gpio", "/linux_gpios/GPIOState"
+
     # Input command
     #
     # type: Speed
@@ -146,7 +150,7 @@ task_context "SimulationTask" do
     error_states :CONTROLLER_FAULT
 
     exception_states :INVALID_COMMAND_SIZE, :INVALID_COMMAND_PARAMETER,
-                     :INVALID_JOINT_NAME
+                     :INVALID_JOINT_NAME, :IO_TIMEOUT
 
     periodic 0.1
 end

--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -107,6 +107,8 @@ end
 task_context "SimulationTask" do
     needs_configuration
 
+    property "contactor_fault_probabilities", "/motors_weg_cvw300/ContactorFaultProbabilities"
+
     # The controlled joint name at the sdf file
     property "joint_name", "/std/string"
 

--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -107,6 +107,7 @@ end
 task_context "SimulationTask" do
     needs_configuration
 
+    # The probabilities to emit and exit the contactor fault
     property "contactor_fault_probabilities", "/motors_weg_cvw300/ContactorFaultProbabilities"
 
     # The controlled joint name at the sdf file

--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -129,9 +129,7 @@ task_context "SimulationTask" do
 
     input_port "external_fault_gpio", "/linux_gpios/GPIOState"
 
-    input_port "port_power_disable_gpio", "/linux_gpios/GPIOState"
-
-    input_port "starboard_power_disable_gpio", "/linux_gpios/GPIOState"
+    input_port "power_disable_gpio", "/linux_gpios/GPIOState"
 
     # Input command
     #

--- a/motors_weg_cvw300Types.hpp
+++ b/motors_weg_cvw300Types.hpp
@@ -52,10 +52,7 @@ namespace motors_weg_cvw300 {
          * @brief The probability to reset the fault with a soft reset
          */
         double soft_reset_sucess = base::unknown<double>();
-        /**
-         * @brief The probability to reset the fault with a hard reset
-         */
-        double hard_reset_sucess = base::unknown<double>();
+    };
     };
 
 }

--- a/motors_weg_cvw300Types.hpp
+++ b/motors_weg_cvw300Types.hpp
@@ -39,7 +39,7 @@ namespace motors_weg_cvw300 {
     };
 
     /**
-     * @brief The probabilities associated to the simulation of the contactor fault emission
+     * @brief The probabilities associated to the simulation of the contactor fault
      *
      * Each value must be between 0 and 1
      */
@@ -53,6 +53,11 @@ namespace motors_weg_cvw300 {
          */
         double soft_reset_sucess = base::unknown<double>();
     };
+
+    enum Fault {
+        NO_FAULT = 0,
+        EXTERNAL_FAULT = 91,
+        CONTACTOR_FAULT = 185
     };
 
 }

--- a/motors_weg_cvw300Types.hpp
+++ b/motors_weg_cvw300Types.hpp
@@ -49,9 +49,9 @@ namespace motors_weg_cvw300 {
          */
         double trigger = base::unknown<double>();
         /**
-         * @brief The probability to reset the fault with a soft reset
+         * @brief The probability of the external fault break the current contactor fault
          */
-        double soft_reset_sucess = base::unknown<double>();
+        double break_on_external_fault = base::unknown<double>();
     };
 
     enum Fault {

--- a/motors_weg_cvw300Types.hpp
+++ b/motors_weg_cvw300Types.hpp
@@ -1,11 +1,12 @@
 #ifndef motors_weg_cvw300_TYPES_HPP
 #define motors_weg_cvw300_TYPES_HPP
 
+#include <base/Float.hpp>
 #include <base/Time.hpp>
 #include <motors_weg_cvw300/Configuration.hpp>
+#include <motors_weg_cvw300/CurrentState.hpp>
 #include <motors_weg_cvw300/FaultState.hpp>
 #include <motors_weg_cvw300/InverterStatus.hpp>
-#include <motors_weg_cvw300/CurrentState.hpp>
 
 namespace motors_weg_cvw300 {
     namespace configuration {
@@ -36,6 +37,27 @@ namespace motors_weg_cvw300 {
         base::Time time;
         int current_alarm;
     };
+
+    /**
+     * @brief The probabilities associated to the simulation of the contactor fault emission
+     *
+     * Each value must be between 0 and 1
+     */
+    struct ContactorFaultProbabilities {
+        /**
+         * @brief The probability to trigger a contactor fault
+         */
+        double trigger = base::unknown<double>();
+        /**
+         * @brief The probability to reset the fault with a soft reset
+         */
+        double soft_reset_sucess = base::unknown<double>();
+        /**
+         * @brief The probability to reset the fault with a hard reset
+         */
+        double hard_reset_sucess = base::unknown<double>();
+    };
+
 }
 
 #endif

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -160,7 +160,7 @@ void SimulationTask::possiblyTriggerContactorFault()
 {
     if (m_current_fault_state == Fault::NO_FAULT &&
         rollProbability(m_contactor_fault_probabilities.trigger)) {
-        m_current_fault_state = Fault::NO_FAULT;
+        m_current_fault_state = Fault::CONTACTOR_FAULT;
     }
 }
 

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -238,7 +238,7 @@ void SimulationTask::readPortPowerDisableGPIOState()
     linux_gpios::GPIOState port_power_disable;
     if (_port_power_disable_gpio.read(port_power_disable) == RTT::NewData &&
         port_power_disable.states[0].data) {
-        simulateHardReset();
+        return exception(IO_TIMEOUT);
     }
 }
 
@@ -247,13 +247,8 @@ void SimulationTask::readStarboardPowerDisableGPIOState()
     linux_gpios::GPIOState starboard_power_disable;
     if (_starboard_power_disable_gpio.read(starboard_power_disable) == RTT::NewData &&
         starboard_power_disable.states[0].data) {
-        simulateHardReset();
+        return exception(IO_TIMEOUT);
     }
-}
-
-void SimulationTask::simulateHardReset()
-{
-    return exception(IO_TIMEOUT);
 }
 
 InverterState SimulationTask::currentState() const

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -146,6 +146,8 @@ void SimulationTask::updateHook()
     }
 
     readExternalFaultGPIOState();
+    readPortPowerDisableGPIOState();
+    readStarboardPowerDisableGPIOState();
     possiblyTriggerContactorFault();
 
     InverterState state = currentState();
@@ -228,6 +230,29 @@ void SimulationTask::attemptToSoftReset()
     if (rollProbability(m_contactor_fault_probabilities.soft_reset_sucess)) {
         m_current_fault_state = Fault::EXTERNAL_FAULT;
     }
+}
+
+void SimulationTask::readPortPowerDisableGPIOState()
+{
+    linux_gpios::GPIOState port_power_disable;
+    if (_port_power_disable_gpio.read(port_power_disable) == RTT::NewData &&
+        port_power_disable.states[0].data) {
+        simulateHardReset();
+    }
+}
+
+void SimulationTask::readStarboardPowerDisableGPIOState()
+{
+    linux_gpios::GPIOState starboard_power_disable;
+    if (_starboard_power_disable_gpio.read(starboard_power_disable) == RTT::NewData &&
+        starboard_power_disable.states[0].data) {
+        simulateHardReset();
+    }
+}
+
+void SimulationTask::simulateHardReset()
+{
+    return exception(IO_TIMEOUT);
 }
 
 InverterState SimulationTask::currentState() const

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -264,6 +264,7 @@ InverterState SimulationTask::currentState() const
 void SimulationTask::evaluateInverterStatus(InverterStatus status)
 {
     if (status == InverterStatus::STATUS_FAULT) {
+        publishFault();
         error(CONTROLLER_FAULT);
     }
 }
@@ -271,10 +272,10 @@ void SimulationTask::evaluateInverterStatus(InverterStatus status)
 void SimulationTask::errorHook()
 {
     SimulationTaskBase::errorHook();
-    publishFault();
 
     readExternalFaultGPIOState();
     updateFaultState();
+    publishFault();
     _inverter_state.write(currentState());
 
     writeCommandOut(zeroCommand());

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -216,9 +216,9 @@ control_base::SaturationSignal saturationSignal(bool saturation)
 
 void SimulationTask::readExternalFaultGPIOState()
 {
-    linux_gpios::GPIOState estop;
-    if (_external_fault_gpio.read(estop) == RTT::NewData) {
-        m_external_fault = !estop.states[0].data;
+    linux_gpios::GPIOState propulsion_enable;
+    if (_external_fault_gpio.read(propulsion_enable) == RTT::NewData) {
+        m_external_fault = !propulsion_enable.states[0].data;
     }
 }
 

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -153,9 +153,9 @@ void SimulationTask::updateHook()
     if (!m_edge_triggered_fault_state_output) {
         publishFault();
     }
+    readPowerDisableGPIOState();
     readExternalFaultGPIOState();
     updateFaultState();
-    readPowerDisableGPIOState();
 
     InverterState state = currentState();
     _inverter_state.write(state);

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -145,8 +145,7 @@ void SimulationTask::updateHook()
     }
     readExternalFaultGPIOState();
     updateFaultState();
-    readPortPowerDisableGPIOState();
-    readStarboardPowerDisableGPIOState();
+    readPowerDisableGPIOState();
 
     InverterState state = currentState();
     _inverter_state.write(state);
@@ -233,20 +232,11 @@ bool SimulationTask::exitContactorFault()
     return rollProbability(m_contactor_fault_probabilities.break_on_external_fault);
 }
 
-void SimulationTask::readPortPowerDisableGPIOState()
+void SimulationTask::readPowerDisableGPIOState()
 {
-    linux_gpios::GPIOState port_power_disable;
-    if (_port_power_disable_gpio.read(port_power_disable) == RTT::NewData &&
-        port_power_disable.states[0].data) {
-        return exception(IO_TIMEOUT);
-    }
-}
-
-void SimulationTask::readStarboardPowerDisableGPIOState()
-{
-    linux_gpios::GPIOState starboard_power_disable;
-    if (_starboard_power_disable_gpio.read(starboard_power_disable) == RTT::NewData &&
-        starboard_power_disable.states[0].data) {
+    linux_gpios::GPIOState power_disable;
+    if (_power_disable_gpio.read(power_disable) == RTT::NewData &&
+        power_disable.states[0].data) {
         return exception(IO_TIMEOUT);
     }
 }

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -271,6 +271,7 @@ void SimulationTask::errorHook()
 {
     SimulationTaskBase::errorHook();
 
+    readPowerDisableGPIOState();
     readExternalFaultGPIOState();
     m_current_fault_state = updateFaultState(m_current_fault_state, m_external_fault);
     publishFault();

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -3,18 +3,17 @@
 #include "SimulationTask.hpp"
 
 #include <control_base/SaturationSignal.hpp>
-#include <random>
 
 using namespace motors_weg_cvw300;
 using namespace std;
 
 base::samples::Joints speedCommand(float cmd, std::string const& joint_name);
 control_base::SaturationSignal saturationSignal(bool saturation);
-bool rollProbability(double probability);
 
 SimulationTask::SimulationTask(std::string const& name)
     : SimulationTaskBase(name)
 {
+    std::mt19937 m_distribution_generator(std::random_device{}());
 }
 
 SimulationTask::~SimulationTask()
@@ -164,12 +163,10 @@ void SimulationTask::possiblyTriggerContactorFault()
     }
 }
 
-bool rollProbability(double probability)
+bool SimulationTask::rollProbability(double probability)
 {
-    random_device random_device;
-    mt19937 generator(random_device());
     bernoulli_distribution distribution(probability);
-    return distribution(generator);
+    return distribution(m_distribution_generator);
 }
 
 bool SimulationTask::validateCommand(base::samples::Joints cmd,

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -224,7 +224,7 @@ void SimulationTask::updateFaultState(bool gpio_propulsion_enable_value)
 
 void SimulationTask::attemptToSoftReset()
 {
-    if (rollProbability(m_contactor_fault_probabilities.soft_reset_sucess)) {
+    if (rollProbability(m_contactor_fault_probabilities.break_on_external_fault)) {
         m_current_fault_state = Fault::EXTERNAL_FAULT;
     }
 }

--- a/tasks/SimulationTask.cpp
+++ b/tasks/SimulationTask.cpp
@@ -155,7 +155,7 @@ void SimulationTask::updateHook()
     if (!m_edge_triggered_fault_state_output) {
         publishFault();
     }
-    if(readPowerDisableGPIOState()){
+    if (readPowerDisableGPIOState()) {
         // This simulates the motor power off through the power_disable_gpio
         return exception(IO_TIMEOUT);
     };
@@ -229,6 +229,8 @@ Fault SimulationTask::updateFaultState(Fault const& current_fault_state,
         return Fault::NO_FAULT;
     }
     if (triggerContactorFault()) {
+        // Ideally, the contactor fault trigger roll should occur before the external
+        // fault exit. However, placing it there would make the logic much harder to test.
         return Fault::CONTACTOR_FAULT;
     }
     if (external_fault) {
@@ -274,7 +276,7 @@ void SimulationTask::errorHook()
 {
     SimulationTaskBase::errorHook();
 
-    if(readPowerDisableGPIOState()){
+    if (readPowerDisableGPIOState()) {
         // This simulates the motor power off through the power_disable_gpio
         return exception(IO_TIMEOUT);
     };

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -78,7 +78,7 @@ namespace motors_weg_cvw300 {
          */
         void readExternalFaultGPIOState();
 
-        void readPowerDisableGPIOState();
+        bool readPowerDisableGPIOState();
 
         void evaluateInverterStatus(InverterStatus status);
 

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -56,7 +56,7 @@ namespace motors_weg_cvw300 {
 
         void setupDistributionsAndGenerator();
 
-        void updateFaultState();
+        Fault updateFaultState(Fault const& current_fault_state, bool external_fault);
 
         bool triggerContactorFault();
 
@@ -66,7 +66,8 @@ namespace motors_weg_cvw300 {
 
         void writeCommandOut(base::samples::Joints const& cmd);
 
-        InverterStatus inverterStatus() const;
+        static InverterStatus inverterStatus(Fault const& current_falt,
+            base::samples::Joints const& last_command_out);
 
         void publishFault();
 

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -73,9 +73,7 @@ namespace motors_weg_cvw300 {
          */
         void readExternalFaultGPIOState();
 
-        void readStarboardPowerDisableGPIOState();
-
-        void readPortPowerDisableGPIOState();
+        void readPowerDisableGPIOState();
 
         void evaluateInverterStatus(InverterStatus status);
 

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -4,6 +4,7 @@
 #define MOTORS_WEG_CVW300_SIMULATIONTASK_TASK_HPP
 
 #include "motors_weg_cvw300/SimulationTaskBase.hpp"
+#include <random>
 
 namespace motors_weg_cvw300 {
 
@@ -47,6 +48,8 @@ namespace motors_weg_cvw300 {
          */
         base::samples::Joints m_last_command_out;
 
+        std::mt19937 m_distribution_generator;
+
         void updateFaultState(bool gpio_propulsion_enable_value);
 
         void possiblyTriggerContactorFault();
@@ -75,6 +78,8 @@ namespace motors_weg_cvw300 {
         void simulateHardReset();
 
         void evaluateInverterStatus(InverterStatus status);
+
+        bool rollProbability(double probability);
 
     public:
         bool validateCommand(base::samples::Joints cmd,

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -36,8 +36,7 @@ namespace motors_weg_cvw300 {
         bool m_edge_triggered_fault_state_output;
         // end component properties
 
-        bool m_external_fault;
-        bool m_contactor_fault;
+        Fault m_current_fault_state;
         ContactorFaultProbabilities m_contactor_fault_probabilities;
         base::Time m_cmd_deadline;
 
@@ -48,15 +47,17 @@ namespace motors_weg_cvw300 {
          */
         base::samples::Joints m_last_command_out;
 
-        void triggerContactorFaultIfRollPasses();
+        void updateFaultState(bool gpio_propulsion_enable_value);
+
+        void possiblyTriggerContactorFault();
+
+        void attemptToSoftReset();
 
         void updateWatchdog();
 
         void writeCommandOut(base::samples::Joints const& cmd);
 
         InverterStatus inverterStatus() const;
-
-        std::uint16_t currentFault() const;
 
         void publishFault();
 

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -37,6 +37,8 @@ namespace motors_weg_cvw300 {
         // end component properties
 
         bool m_external_fault;
+        bool m_contactor_fault;
+        ContactorFaultProbabilities m_contactor_fault_probabilities;
         base::Time m_cmd_deadline;
 
         base::samples::Joints m_zero_command;
@@ -45,6 +47,8 @@ namespace motors_weg_cvw300 {
          * placeholder for the last command written in cmd_out port
          */
         base::samples::Joints m_last_command_out;
+
+        void triggerContactorFaultIfRollPasses();
 
         void updateWatchdog();
 

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -50,11 +50,13 @@ namespace motors_weg_cvw300 {
 
         std::mt19937 m_distribution_generator;
 
-        void updateFaultState(bool gpio_propulsion_enable_value);
+        bool m_external_fault;
 
-        void possiblyTriggerContactorFault();
+        void updateFaultState();
 
-        void attemptToSoftReset();
+        bool triggerContactorFault();
+
+        bool exitContactorFault();
 
         void updateWatchdog();
 

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -48,9 +48,13 @@ namespace motors_weg_cvw300 {
          */
         base::samples::Joints m_last_command_out;
 
-        std::mt19937 m_distribution_generator;
-
         bool m_external_fault;
+
+        std::mt19937 m_distribution_generator;
+        std::bernoulli_distribution m_trigger_distribution;
+        std::bernoulli_distribution m_break_on_external_fault_distribution;
+
+        void setupDistributionsAndGenerator();
 
         void updateFaultState();
 
@@ -77,7 +81,7 @@ namespace motors_weg_cvw300 {
 
         void evaluateInverterStatus(InverterStatus status);
 
-        bool rollProbability(double probability);
+        bool rollProbability(std::bernoulli_distribution& distribution);
 
     public:
         bool validateCommand(base::samples::Joints cmd,

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -77,8 +77,6 @@ namespace motors_weg_cvw300 {
 
         void readPortPowerDisableGPIOState();
 
-        void simulateHardReset();
-
         void evaluateInverterStatus(InverterStatus status);
 
         bool rollProbability(double probability);

--- a/tasks/SimulationTask.hpp
+++ b/tasks/SimulationTask.hpp
@@ -68,6 +68,12 @@ namespace motors_weg_cvw300 {
          */
         void readExternalFaultGPIOState();
 
+        void readStarboardPowerDisableGPIOState();
+
+        void readPortPowerDisableGPIOState();
+
+        void simulateHardReset();
+
         void evaluateInverterStatus(InverterStatus status);
 
     public:

--- a/test/simulation_task_test.rb
+++ b/test/simulation_task_test.rb
@@ -197,6 +197,17 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
                 maintain(at_least_during: 1) { task.orogen_state == :CONTROLLER_FAULT }
             end
         end
+        it "does not keeps publishing fault and inverter state after an IO_TIMEOUT "\
+           "errorHook" do
+            syskit_configure_and_start(task)
+            expect_execution do
+                syskit_write task.power_disable_gpio_port, gpio_state(true)
+            end.to do
+                emit task.io_timeout_event
+                have_no_new_sample task.inverter_state_port
+                have_no_new_sample task.fault_state_port
+            end
+        end
     end
 
     describe "fault reporting" do

--- a/test/simulation_task_test.rb
+++ b/test/simulation_task_test.rb
@@ -9,6 +9,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
         @task = syskit_deploy(
             OroGen.motors_weg_cvw300.SimulationTask
                   .deployed_as("test_task")
+                #   .deployed_as_unmanaged("test_task")
         )
 
         @task.properties.limits = Types.base.JointLimits.new(
@@ -19,6 +20,11 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
             }]
         )
         @task.properties.joint_name = "joint"
+        @task.properties.contactor_fault_probabilities =
+            Types.motors_weg_cvw300.ContactorFaultProbabilities.new(
+                trigger: 0,
+                soft_reset_sucess: 0
+            )
     end
 
     describe "configure" do

--- a/test/simulation_task_test.rb
+++ b/test/simulation_task_test.rb
@@ -22,7 +22,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
         @task.properties.contactor_fault_probabilities =
             Types.motors_weg_cvw300.ContactorFaultProbabilities.new(
                 trigger: 0,
-                soft_reset_sucess: 0
+                break_on_external_fault: 0
             )
     end
 
@@ -170,7 +170,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
             @task.properties.contactor_fault_probabilities =
             Types.motors_weg_cvw300.ContactorFaultProbabilities.new(
                 trigger: 100,
-                soft_reset_sucess: 0
+                break_on_external_fault: 0
             )
             syskit_configure_and_start(task)
 
@@ -255,7 +255,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
             @task.properties.contactor_fault_probabilities =
                 Types.motors_weg_cvw300.ContactorFaultProbabilities.new(
                     trigger: 100,
-                    soft_reset_sucess: 0
+                    break_on_external_fault: 0
                 )
             syskit_configure(task)
             expect_execution { task.start! }
@@ -271,7 +271,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
             @task.properties.contactor_fault_probabilities =
                 Types.motors_weg_cvw300.ContactorFaultProbabilities.new(
                     trigger: 100,
-                    soft_reset_sucess: 100
+                    break_on_external_fault: 100
                 )
             syskit_configure_and_start(task)
             expect_execution.to do

--- a/test/simulation_task_test.rb
+++ b/test/simulation_task_test.rb
@@ -201,6 +201,13 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
            "errorHook" do
             syskit_configure_and_start(task)
             expect_execution do
+                syskit_write task.external_fault_gpio_port, gpio_state(false)
+            end.to do
+                emit task.runtime_error_event
+                emit task.controller_fault_event
+            end
+
+            expect_execution do
                 syskit_write task.power_disable_gpio_port, gpio_state(true)
             end.to do
                 emit task.io_timeout_event

--- a/test/simulation_task_test.rb
+++ b/test/simulation_task_test.rb
@@ -163,7 +163,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
                 .to_not_emit task.controller_fault_event
 
             expect_execution do
-                syskit_write task.external_fault_gpio_port, propulsion_enable(false)
+                syskit_write task.external_fault_gpio_port, gpio_state(false)
             end.to_emit task.controller_fault_event
         end
 
@@ -178,7 +178,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
         it "keeps publishing fault and inverter state while on errorHook" do
             syskit_configure_and_start(task)
             expect_execution do
-                syskit_write task.external_fault_gpio_port, propulsion_enable(false)
+                syskit_write task.external_fault_gpio_port, gpio_state(false)
             end.to_emit task.controller_fault_event
 
             expect_execution.to do
@@ -200,7 +200,7 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
             syskit_configure_and_start(task)
 
             fault, state = expect_execution do
-                syskit_write task.external_fault_gpio_port, propulsion_enable(false)
+                syskit_write task.external_fault_gpio_port, gpio_state(false)
             end.to do
                 emit task.controller_fault_event
                 [
@@ -217,11 +217,11 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
            "gpio goes off" do
             syskit_configure_and_start(task)
             expect_execution do
-                syskit_write task.external_fault_gpio_port, propulsion_enable(false)
+                syskit_write task.external_fault_gpio_port, gpio_state(false)
             end.to_emit task.controller_fault_event
 
             expect_execution do
-                syskit_write task.external_fault_gpio_port, propulsion_enable(true)
+                syskit_write task.external_fault_gpio_port, gpio_state(true)
             end.to do
                 have_one_new_sample(task.inverter_state_port)
                     .matching { |s| s.inverter_status == :STATUS_READY }
@@ -233,18 +233,16 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
            "inverter is in fault status" do
             syskit_configure_and_start(task)
             expect_execution do
-                syskit_write task.external_fault_gpio_port, propulsion_enable(false)
+                syskit_write task.external_fault_gpio_port, gpio_state(false)
             end.to_emit task.controller_fault_event
 
             cmd = expect_execution.to { have_new_samples(task.cmd_out_port, 5) }
             cmd.each { |s| assert_zero_cmd(s) }
         end
-    end
-
-    def propulsion_enable(enabled)
+    def gpio_state(value)
         Types.linux_gpios.GPIOState.new(
             states: [
-                Types.raw_io.Digital.new(data: enabled)
+                Types.raw_io.Digital.new(data: value)
             ]
         )
     end

--- a/test/simulation_task_test.rb
+++ b/test/simulation_task_test.rb
@@ -296,21 +296,10 @@ describe OroGen.motors_weg_cvw300.SimulationTask do
             end
         end
 
-        it "emits a IO_TIMEOUT when there is a high value at port_power_disable_gpio "\
-           "port" do
+        it "emits a IO_TIMEOUT when there is a high value at power_disable_gpio port" do
             syskit_configure_and_start(task)
             expect_execution do
-                syskit_write task.port_power_disable_gpio_port, gpio_state(true)
-            end.to do
-                emit task.io_timeout_event
-            end
-        end
-
-        it "emits a IO_TIMEOUT when there is a high value at "\
-           "starboard_power_disable_gpio port" do
-            syskit_configure_and_start(task)
-            expect_execution do
-                syskit_write task.starboard_power_disable_gpio_port, gpio_state(true)
+                syskit_write task.power_disable_gpio_port, gpio_state(true)
             end.to do
                 emit task.io_timeout_event
             end


### PR DESCRIPTION
# What is this PR for
Simulate the contactor fault
Refactor the fault state update 
implement the hard and the soft reset

# How I did it
There is a probability associated to the emission of the contactor fault at each update hook and a probability associate to the success of the soft reset.
The hard reset  will kill the component and will always reset the fault (since the fault state is none at the start hook)

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)
