### PR TITLE
feat: report RTU statistics

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,6 +10,7 @@
   <depend package="drivers/orogen/iodrivers_base" />
   <depend package="drivers/orogen/linux_gpios" />
   <depend package="control/orogen/control_base" />
+  <depend package="drivers/modbus" />
 
   <test_depend package="tools/syskit" />
 </package>

--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -123,7 +123,7 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     #
     # Reports the RTU Statistics on a fixed interval unless a change
     # on an error counter has been detected, in this case it outputs
-    # immediatelly
+    # immediately
     output_port "modbus_rtu_statistics", "/modbus/RTUStatistics"
 
     exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER"

--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -75,6 +75,12 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # the error count by 1 until 0 and it cannot be modified.
     property "modbus_error_count_increment", "uint8_t", 1
 
+    # Modbus RTU Statistics output period
+    #
+    # The period of update for the modbus rtu statistics port if
+    # no increment on the error counter was detected. Default: 10 seconds
+    property "modbus_rtu_statistics_period", "/base/Time"
+
     # Control limits
     #
     # You may only set the speed and effort fields. Setting any other field
@@ -113,7 +119,12 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
 
     output_port "saturation_signal", "/control_base/SaturationSignal"
 
-    output_port "rtu_statistics", "/modbus/RTUStatistics"
+    # RTU Statistics
+    #
+    # Reports the RTU Statistics on a fixed interval unless a change
+    # on an error counter has been detected, in this case it outputs
+    # immediatelly
+    output_port "modbus_rtu_statistics", "/modbus/RTUStatistics"
 
     exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER"
     error_states "CONTROLLER_FAULT", "CONTROLLER_UNDER_VOLTAGE"

--- a/motors_weg_cvw300.orogen
+++ b/motors_weg_cvw300.orogen
@@ -7,6 +7,9 @@ cxx_standard "c++17"
 import_types_from "std"
 import_types_from "base"
 
+using_library "modbus"
+import_types_from "modbus/RTUStatistics.hpp"
+
 using_library "motors_weg_cvw300"
 import_types_from "motors_weg_cvw300/Configuration.hpp"
 import_types_from "motors_weg_cvw300/InverterTemperatures.hpp"
@@ -58,6 +61,20 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # setup (and know what you are doing)
     property "modbus_interframe_delay", "/base/Time"
 
+    # Modbus error threshold
+    #
+    # The default value is 1, therefore it retains the previous behavior
+    # of breaking once a CRC or Reply error is detected.
+    property "modbus_error_count_threshold", "uint8_t", 1
+
+    # Modbus error count increment
+    #
+    # The increment applied to the error counter after each error.
+    # This avoids alternating errors (ERROR, SUCESS, ERROR, SUCESS...) by
+    # by being more sensible to errors since a sucess will always decreaser
+    # the error count by 1 until 0 and it cannot be modified.
+    property "modbus_error_count_increment", "uint8_t", 1
+
     # Control limits
     #
     # You may only set the speed and effort fields. Setting any other field
@@ -95,6 +112,8 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     output_port "fault_state", "/motors_weg_cvw300/FaultState"
 
     output_port "saturation_signal", "/control_base/SaturationSignal"
+
+    output_port "rtu_statistics", "/modbus/RTUStatistics"
 
     exception_states "INVALID_COMMAND_SIZE", "INVALID_COMMAND_PARAMETER"
     error_states "CONTROLLER_FAULT", "CONTROLLER_UNDER_VOLTAGE"

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -13,6 +13,7 @@ Task::Task(std::string const& name)
     : TaskBase(name)
 {
     _modbus_interframe_delay.set(base::Time::fromMilliseconds(20));
+    _modbus_rtu_statistics_period.set(base::Time::fromSeconds(10));
 }
 
 Task::~Task()
@@ -49,6 +50,7 @@ bool Task::configureHook()
     driver->setInterframeDelay(_modbus_interframe_delay.get());
     driver->setErrorIncrement(_modbus_error_count_increment.get());
     driver->setErrorThreshold(_modbus_error_count_threshold.get());
+    m_modbus_rtu_statistics_period = _modbus_rtu_statistics_period.get();
 
     driver->readMotorRatings();
     driver->disable();
@@ -166,8 +168,33 @@ void Task::publishFault()
 
 void Task::publishRTUStatistics()
 {
-    auto rtu_statistics = m_driver->getRTUStats();
-    _rtu_statistics.write(rtu_statistics);
+    m_modbus_rtu_statistics = m_driver->getRTUStats();
+    m_modbus_rtu_statistics_deadline = Time::now() + m_modbus_rtu_statistics_period;
+    _modbus_rtu_statistics.write(m_modbus_rtu_statistics);
+}
+
+void Task::publishUpdatedRTUStatistics()
+{
+    auto new_status = m_driver->getRTUStats();
+    if (errorCountersUpdated(new_status) || rtuStatisticsDeadlineReached()) {
+        m_modbus_rtu_statistics = new_status;
+        m_modbus_rtu_statistics_deadline = Time::now() + m_modbus_rtu_statistics_period;
+        _modbus_rtu_statistics.write(m_modbus_rtu_statistics);
+    }
+}
+
+bool Task::rtuStatisticsDeadlineReached()
+{
+    return (Time::now() > m_modbus_rtu_statistics_deadline);
+}
+
+bool Task::errorCountersUpdated(modbus::RTUStatistics const& new_status)
+{
+    return (m_modbus_rtu_statistics.error_count != new_status.error_count ||
+            m_modbus_rtu_statistics.total_crc_error_count !=
+                new_status.total_crc_error_count ||
+            m_modbus_rtu_statistics.total_unexpected_reply_error_count !=
+                new_status.total_unexpected_reply_error_count);
 }
 
 void Task::updateHook()
@@ -201,7 +228,7 @@ void Task::updateHook()
     }
     auto state = readAndPublishControllerStates();
     evaluateInverterStatus(state.inverter_status);
-    publishRTUStatistics();
+    publishUpdatedRTUStatistics();
 }
 void Task::processIO()
 {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -1,7 +1,6 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
 #include "Task.hpp"
-#include <base-logging/Logging.hpp>
 #include <iodrivers_base/ConfigureGuard.hpp>
 #include <motors_weg_cvw300/Driver.hpp>
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -47,6 +47,8 @@ bool Task::configureHook()
     }
 
     driver->setInterframeDelay(_modbus_interframe_delay.get());
+    driver->setErrorIncrement(_modbus_error_count_increment.get());
+    driver->setErrorThreshold(_modbus_error_count_threshold.get());
 
     driver->readMotorRatings();
     driver->disable();
@@ -93,6 +95,7 @@ bool Task::startHook()
     m_last_temperature_update = Time();
 
     publishFault();
+    publishRTUStatistics();
     return true;
 }
 bool Task::commandTimedOut() const
@@ -160,6 +163,13 @@ void Task::publishFault()
     auto fault_state = m_driver->readFaultState();
     _fault_state.write(fault_state);
 }
+
+void Task::publishRTUStatistics()
+{
+    auto rtu_statistics = m_driver->getRTUStats();
+    _rtu_statistics.write(rtu_statistics);
+}
+
 void Task::updateHook()
 {
     TaskBase::updateHook();
@@ -191,6 +201,7 @@ void Task::updateHook()
     }
     auto state = readAndPublishControllerStates();
     evaluateInverterStatus(state.inverter_status);
+    publishRTUStatistics();
 }
 void Task::processIO()
 {
@@ -200,6 +211,7 @@ void Task::errorHook()
 {
     TaskBase::errorHook();
 
+    publishRTUStatistics();
     publishFault();
 
     // Try to reset the faults
@@ -218,6 +230,7 @@ void Task::errorHook()
 }
 void Task::stopHook()
 {
+    publishRTUStatistics();
     m_driver->disable();
     TaskBase::stopHook();
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -1,6 +1,7 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
 #include "Task.hpp"
+#include <base-logging/Logging.hpp>
 #include <iodrivers_base/ConfigureGuard.hpp>
 #include <motors_weg_cvw300/Driver.hpp>
 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -46,6 +46,7 @@ namespace motors_weg_cvw300 {
         void writeSpeedCommand(float cmd);
         bool commandTimedOut() const;
         void publishFault();
+        void publishRTUStatistics();
         bool checkSpeedSaturation(base::commands::Joints const& cmd);
         void evaluateInverterStatus(InverterStatus const& inverter_status);
         CurrentState readAndPublishControllerStates();

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -37,6 +37,9 @@ namespace motors_weg_cvw300 {
         base::Time m_last_temperature_update;
         base::Time m_cmd_timeout;
         base::Time m_cmd_deadline;
+        base::Time m_modbus_rtu_statistics_period;
+        base::Time m_modbus_rtu_statistics_deadline;
+        modbus::RTUStatistics m_modbus_rtu_statistics;
 
         std::unique_ptr<Driver> m_driver;
 
@@ -46,11 +49,32 @@ namespace motors_weg_cvw300 {
         void writeSpeedCommand(float cmd);
         bool commandTimedOut() const;
         void publishFault();
-        void publishRTUStatistics();
         bool checkSpeedSaturation(base::commands::Joints const& cmd);
         void evaluateInverterStatus(InverterStatus const& inverter_status);
         CurrentState readAndPublishControllerStates();
 
+        /** Signalizes that the RTUStatistics must be updated and published */
+        bool errorCountersUpdated(modbus::RTUStatistics const& new_status);
+
+        /** Signalizes that the RTUStatistics update period has been reached
+         *  and it must be published */
+        bool rtuStatisticsDeadlineReached();
+
+        /** Publish RTU Statistics under certain constraints to avoid flooding the logs
+         *
+         *  It also updates the deadline and the stored RTUStatistics values.
+         *  It's meant to be used on the UpdateHook only.
+        */
+        void publishUpdatedRTUStatistics();
+
+        /** Immediately publishes RTU Statistics and updates deadline
+         *
+         *  This is meant to be used on StartHook, StopHook and ErrorHook
+         *  providing the newest and first/last sample from the task.
+         *  It also updates the stored statistics variable and deadline
+         *  so we can use it on StartHook to initialize the values.
+         */
+        void publishRTUStatistics();
     public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it

--- a/test/modbus_helpers.rb
+++ b/test/modbus_helpers.rb
@@ -130,6 +130,7 @@ module ModbusHelpers
             address = sample.data[2] << 8 | sample.data[3]
             value = sample.data[4] << 8 | sample.data[5]
             @modbus_registers[address] = value
+            return Types.iodrivers_base.RawPacket.new(time: Time.now, data: sample.data)
         elsif [3, 4].include?(function) # Read registers
             start_address  = sample.data[2] << 8 | sample.data[3]
             register_count = sample.data[4] << 8 | sample.data[5]

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -683,6 +683,27 @@ describe OroGen.motors_weg_cvw300.Task do
             assert_equal(0, sample.total_unexpected_reply_error_count)
         end
 
+        it "detects an error if an extra 0 is sent after CRC" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(999)
+            @task.properties.modbus_error_count_threshold = 10
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+            end
+
+            request = expect_execution.to_have_one_new_sample(@reader)
+            reply = modbus_reply(request)
+            # Modify the reply to add the extra 0
+            reply.data << 0
+
+            sample = modbus_expect_execution(@writer, @reader) do
+                @writer.write(reply)
+            end.to_have_one_new_sample(task.modbus_rtu_statistics_port)
+
+            assert(task.running?)
+            assert_equal(0, sample.total_crc_error_count)
+            assert_equal(1, sample.total_unexpected_reply_error_count)
+        end
+
         it "updates the deadline for rtu stats after an error has been detected" do
             @task.properties.modbus_rtu_statistics_period = Time.at(1)
             @task.properties.modbus_error_count_threshold = 10
@@ -692,7 +713,7 @@ describe OroGen.motors_weg_cvw300.Task do
 
             request = expect_execution.to_have_one_new_sample(@reader)
             reply = modbus_reply(request)
-            # Modify the reply to add the error
+            # Modify the reply to add an error
             reply.data[5] += 1
 
             toc = Time.now

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -632,12 +632,17 @@ describe OroGen.motors_weg_cvw300.Task do
                 emit task.start_event
                 have_one_new_sample task.modbus_rtu_statistics_port
             end
+
             toc = Time.now
-            expect_execution { have_one_new_sample task.modbus_rtu_statistics_port }
-            expect_execution { have_one_new_sample task.modbus_rtu_statistics_port }
+            modbus_expect_execution(@writer, @reader).to do
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
+            modbus_expect_execution(@writer, @reader).to do
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
             tic = Time.now
 
-            assert_in_delta((tic - toc), 2, 0.3)
+            assert_includes (1.7..2.3), tic - toc
         end
 
         it "sends a rtu statistic if there is an error count change - CRC" do
@@ -674,7 +679,7 @@ describe OroGen.motors_weg_cvw300.Task do
             assert_equal(1, sample.error_count)
         end
 
-        it "updates the deadline after an error has been detected" do
+        it "updates the deadline for rtu stats after an error has been detected" do
             @task.properties.modbus_rtu_statistics_period = Time.at(1)
             @task.properties.modbus_error_count_threshold = 10
             modbus_expect_during_configuration_and_start.to do

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -613,6 +613,86 @@ describe OroGen.motors_weg_cvw300.Task do
         end
     end
 
+    describe "modbus RTU statistics" do
+        it "sends a rtu statistic on startup" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(999)
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
+
+            modbus_expect_execution(@writer, @reader).to do
+                have_no_new_sample(task.modbus_rtu_statistics_port, at_least_during: 2)
+            end
+        end
+
+        it "sends a rtu statistic periodically after 1 sec independently" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(1)
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
+            toc = Time.now
+            expect_execution { have_one_new_sample task.modbus_rtu_statistics_port }
+            expect_execution { have_one_new_sample task.modbus_rtu_statistics_port }
+            tic = Time.now
+
+            assert_in_delta((tic - toc), 2, 0.3)
+        end
+
+        it "sends a rtu statistic if there is an error count change - CRC" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(999)
+            @task.properties.modbus_error_count_threshold = 10
+            # Avoid heisenbug because of the first sample
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
+
+            sample =
+                expect_execution { @writer.write({ time: Time.now, data: [0, 1, 2, 3] }) }
+                .to { have_one_new_sample task.modbus_rtu_statistics_port }
+
+            assert_equal(1, sample.total_crc_error_count)
+            assert_equal(0, sample.total_unexpected_reply_error_count)
+            assert_equal(1, sample.error_count)
+        end
+
+        it "sends a rtu statistic if there is an error count change - UnexpectedReply" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(999)
+            @task.properties.modbus_error_count_threshold = 10
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
+            sample =
+                expect_execution { @writer.write({ time: Time.now, data: [0] }) }
+                .to { have_one_new_sample task.modbus_rtu_statistics_port }
+
+            assert_equal(0, sample.total_crc_error_count)
+            assert_equal(1, sample.total_unexpected_reply_error_count)
+            assert_equal(1, sample.error_count)
+        end
+
+        it "updates the deadline after an error has been detected" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(1)
+            @task.properties.modbus_error_count_threshold = 10
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+                have_one_new_sample task.modbus_rtu_statistics_port
+            end
+            toc = Time.now
+            sample =
+                expect_execution { @writer.write({ time: Time.now, data: [0, 1, 2, 3] }) }
+                .to { have_one_new_sample task.modbus_rtu_statistics_port }
+            expect_execution { have_one_new_sample task.modbus_rtu_statistics_port }
+            tic = Time.now
+
+            assert_in_delta((tic - toc), 1, 0.2)
+            assert_equal(1, sample.error_count)
+        end
+    end
+
     def default_deployed_model
         OroGen.motors_weg_cvw300.Task
               .deployed_as("motors_weg_cvw300_test")
@@ -624,6 +704,8 @@ describe OroGen.motors_weg_cvw300.Task do
 
         @task.properties.io_read_timeout = Time.at(2)
         @task.properties.modbus_interframe_delay = Time.at(0.01)
+        @task.properties.modbus_rtu_statistics_period = Time.at(1)
+        @task.properties.modbus_error_count_threshold = 1
         @task.properties.watchdog do |sw|
             sw.timeout = Time.at(0.5)
             sw

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -618,7 +618,6 @@ describe OroGen.motors_weg_cvw300.Task do
             @task.properties.modbus_rtu_statistics_period = Time.at(999)
             modbus_expect_during_configuration_and_start.to do
                 emit task.start_event
-                have_one_new_sample task.modbus_rtu_statistics_port
             end
 
             modbus_expect_execution(@writer, @reader).to do
@@ -630,7 +629,6 @@ describe OroGen.motors_weg_cvw300.Task do
             @task.properties.modbus_rtu_statistics_period = Time.at(1)
             modbus_expect_during_configuration_and_start.to do
                 emit task.start_event
-                have_one_new_sample task.modbus_rtu_statistics_port
             end
 
             toc = Time.now
@@ -645,38 +643,44 @@ describe OroGen.motors_weg_cvw300.Task do
             assert_includes (1.7..2.3), tic - toc
         end
 
-        it "sends a rtu statistic if there is an error count change - CRC" do
-            @task.properties.modbus_rtu_statistics_period = Time.at(999)
-            @task.properties.modbus_error_count_threshold = 10
-            # Avoid heisenbug because of the first sample
-            modbus_expect_during_configuration_and_start.to do
-                emit task.start_event
-                have_one_new_sample task.modbus_rtu_statistics_port
-            end
-
-            sample =
-                expect_execution { @writer.write({ time: Time.now, data: [0, 1, 2, 3] }) }
-                .to { have_one_new_sample task.modbus_rtu_statistics_port }
-
-            assert_equal(1, sample.total_crc_error_count)
-            assert_equal(0, sample.total_unexpected_reply_error_count)
-            assert_equal(1, sample.error_count)
-        end
-
         it "sends a rtu statistic if there is an error count change - UnexpectedReply" do
             @task.properties.modbus_rtu_statistics_period = Time.at(999)
             @task.properties.modbus_error_count_threshold = 10
             modbus_expect_during_configuration_and_start.to do
                 emit task.start_event
-                have_one_new_sample task.modbus_rtu_statistics_port
             end
-            sample =
-                expect_execution { @writer.write({ time: Time.now, data: [0] }) }
-                .to { have_one_new_sample task.modbus_rtu_statistics_port }
+
+            request = expect_execution.to_have_one_new_sample(@reader)
+
+            sample = modbus_expect_execution(@writer, @reader) do
+                # The read response differs from the read requests on the methods
+                # called on update hook, so we can just write the request to avoid
+                # calculating the CRC all over again
+                @writer.write(request)
+            end.to_have_one_new_sample(task.modbus_rtu_statistics_port)
 
             assert_equal(0, sample.total_crc_error_count)
             assert_equal(1, sample.total_unexpected_reply_error_count)
-            assert_equal(1, sample.error_count)
+        end
+
+        it "sends a rtu statistic if there is an error count change - CRC" do
+            @task.properties.modbus_rtu_statistics_period = Time.at(999)
+            @task.properties.modbus_error_count_threshold = 10
+            modbus_expect_during_configuration_and_start.to do
+                emit task.start_event
+            end
+
+            request = expect_execution.to_have_one_new_sample(@reader)
+            reply = modbus_reply(request)
+            # Modify the reply to add the error when validating CRC
+            reply.data[5] += 1
+
+            sample = modbus_expect_execution(@writer, @reader) do
+                @writer.write(reply)
+            end.to_have_one_new_sample(task.modbus_rtu_statistics_port)
+
+            assert_equal(1, sample.total_crc_error_count)
+            assert_equal(0, sample.total_unexpected_reply_error_count)
         end
 
         it "updates the deadline for rtu stats after an error has been detected" do
@@ -684,17 +688,24 @@ describe OroGen.motors_weg_cvw300.Task do
             @task.properties.modbus_error_count_threshold = 10
             modbus_expect_during_configuration_and_start.to do
                 emit task.start_event
+            end
+
+            request = expect_execution.to_have_one_new_sample(@reader)
+            reply = modbus_reply(request)
+            # Modify the reply to add the error
+            reply.data[5] += 1
+
+            toc = Time.now
+            modbus_expect_execution(@writer, @reader) do
+                @writer.write(reply)
+            end.to_have_one_new_sample(task.modbus_rtu_statistics_port)
+
+            modbus_expect_execution(@writer, @reader).to do
                 have_one_new_sample task.modbus_rtu_statistics_port
             end
-            toc = Time.now
-            sample =
-                expect_execution { @writer.write({ time: Time.now, data: [0, 1, 2, 3] }) }
-                .to { have_one_new_sample task.modbus_rtu_statistics_port }
-            expect_execution { have_one_new_sample task.modbus_rtu_statistics_port }
             tic = Time.now
 
-            assert_in_delta((tic - toc), 1, 0.2)
-            assert_equal(1, sample.error_count)
+            assert_includes (0.7..1.3), tic - toc
         end
     end
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-modbus/pull/8
- [ ] https://github.com/tidewise/drivers-motors_weg_cvw300/pull/14

# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
These report the error counts, total error counts and success count

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
